### PR TITLE
fix: incorrect config path for processingExecutablePath

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -35,7 +35,7 @@ export function provideLinter() {
       const folderPath = filePath.substring(0, sign);
       // console.log(filePath, folderPath);
 
-      const command = atom.config.get('linter-processing.processingExecutablePath');
+      const command = atom.config.get('linter-processing-java.processingExecutablePath');
       const parameters = [
         `--sketch=${folderPath}`,
         '--build',


### PR DESCRIPTION
Like [iss5](https://github.com/AtomLinter/linter-processing-java/issues/5) 
when I installed linter-processing-java , I get the error about filePath.
and "linter-processing" need changed to "linter-processing-java"
ths for your continued maintenance!