### PR TITLE
Incorrect config path for processingExecutablePath

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -35,7 +35,7 @@ export function provideLinter() {
       const folderPath = filePath.substring(0, sign);
       // console.log(filePath, folderPath);
 
-      const command = atom.config.get('linter-processing.processingExecutablePath');
+      const command = atom.config.get('linter-processing-java.processingExecutablePath');
       const parameters = [
         `--sketch=${folderPath}`,
         '--build',


### PR DESCRIPTION
Fixes the path used to retrieve the executable path.

Closes #6.
Fixes #5.